### PR TITLE
Add generator and minimal Revit API stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # RevitTestStubs
+
+This repository contains a small utility for generating stub classes from the Autodesk Revit API and a source only package that provides a few hand written stubs used for unit testing. The package exposes minimal `ElementId`, `Element` and `Parameter` implementations with a `Configure` property that allows delegates to be attached for mocking behaviour.
+
+## Projects
+
+- **RevitStubGenerator** – console application that uses `MetadataLoadContext` to read a Revit assembly and emit partial class stubs. The generated files can be added to the source package.
+- **RevitTestStubs** – library that ships source files in a `buildTransitive` folder so they become part of any project referencing the package.
+- **RevitTestStubs.Tests** – xUnit tests demonstrating usage of the stubs.
+
+To create a package run `dotnet pack src/RevitTestStubs` which will produce a source only NuGet package.

--- a/RevitTestStubs.sln
+++ b/RevitTestStubs.sln
@@ -1,0 +1,71 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitTestStubs", "src\RevitTestStubs\RevitTestStubs.csproj", "{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitStubGenerator", "src\RevitStubGenerator\RevitStubGenerator.csproj", "{A5052F16-7CF2-4C78-9F6B-867243693F67}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitTestStubs.Tests", "tests\RevitTestStubs.Tests\RevitTestStubs.Tests.csproj", "{C0A368AF-4410-42FF-B1C4-130ABB4479FE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}.Debug|x64.Build.0 = Debug|Any CPU
+		{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}.Debug|x86.Build.0 = Debug|Any CPU
+		{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}.Release|x64.ActiveCfg = Release|Any CPU
+		{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}.Release|x64.Build.0 = Release|Any CPU
+		{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}.Release|x86.ActiveCfg = Release|Any CPU
+		{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}.Release|x86.Build.0 = Release|Any CPU
+		{A5052F16-7CF2-4C78-9F6B-867243693F67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5052F16-7CF2-4C78-9F6B-867243693F67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5052F16-7CF2-4C78-9F6B-867243693F67}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A5052F16-7CF2-4C78-9F6B-867243693F67}.Debug|x64.Build.0 = Debug|Any CPU
+		{A5052F16-7CF2-4C78-9F6B-867243693F67}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A5052F16-7CF2-4C78-9F6B-867243693F67}.Debug|x86.Build.0 = Debug|Any CPU
+		{A5052F16-7CF2-4C78-9F6B-867243693F67}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5052F16-7CF2-4C78-9F6B-867243693F67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5052F16-7CF2-4C78-9F6B-867243693F67}.Release|x64.ActiveCfg = Release|Any CPU
+		{A5052F16-7CF2-4C78-9F6B-867243693F67}.Release|x64.Build.0 = Release|Any CPU
+		{A5052F16-7CF2-4C78-9F6B-867243693F67}.Release|x86.ActiveCfg = Release|Any CPU
+		{A5052F16-7CF2-4C78-9F6B-867243693F67}.Release|x86.Build.0 = Release|Any CPU
+		{C0A368AF-4410-42FF-B1C4-130ABB4479FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C0A368AF-4410-42FF-B1C4-130ABB4479FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C0A368AF-4410-42FF-B1C4-130ABB4479FE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C0A368AF-4410-42FF-B1C4-130ABB4479FE}.Debug|x64.Build.0 = Debug|Any CPU
+		{C0A368AF-4410-42FF-B1C4-130ABB4479FE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C0A368AF-4410-42FF-B1C4-130ABB4479FE}.Debug|x86.Build.0 = Debug|Any CPU
+		{C0A368AF-4410-42FF-B1C4-130ABB4479FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0A368AF-4410-42FF-B1C4-130ABB4479FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0A368AF-4410-42FF-B1C4-130ABB4479FE}.Release|x64.ActiveCfg = Release|Any CPU
+		{C0A368AF-4410-42FF-B1C4-130ABB4479FE}.Release|x64.Build.0 = Release|Any CPU
+		{C0A368AF-4410-42FF-B1C4-130ABB4479FE}.Release|x86.ActiveCfg = Release|Any CPU
+		{C0A368AF-4410-42FF-B1C4-130ABB4479FE}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{CA82C141-E22A-4CCE-ACD5-E987A4A846E7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{A5052F16-7CF2-4C78-9F6B-867243693F67} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{C0A368AF-4410-42FF-B1C4-130ABB4479FE} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+	EndGlobalSection
+EndGlobal

--- a/src/RevitStubGenerator/Program.cs
+++ b/src/RevitStubGenerator/Program.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace RevitStubGenerator
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Usage: RevitStubGenerator <assemblyPath> <outputDir>");
+                return;
+            }
+
+            var assemblyPath = Path.GetFullPath(args[0]);
+            var outputDir = Path.GetFullPath(args[1]);
+            Directory.CreateDirectory(outputDir);
+
+            var resolver = new PathAssemblyResolver(new[] { assemblyPath });
+            using var mlc = new MetadataLoadContext(resolver);
+            var asm = mlc.LoadFromAssemblyPath(assemblyPath);
+
+            foreach (var type in asm.GetTypes().Where(t => t.IsPublic && !t.IsNested))
+            {
+                if (type.Namespace is null) continue;
+                var code = GenerateStub(type);
+                var fileName = Path.Combine(outputDir, type.Name + ".cs");
+                File.WriteAllText(fileName, code);
+            }
+        }
+
+        private static string GenerateStub(Type type)
+        {
+            var ns = type.Namespace;
+            var baseType = type.BaseType != null && type.BaseType != typeof(object)
+                ? $" : {type.BaseType.FullName}"
+                : string.Empty;
+
+            var writer = new System.Text.StringBuilder();
+            writer.AppendLine("using System;");
+            writer.AppendLine();
+            writer.AppendLine($"namespace {ns}");
+            writer.AppendLine("{");
+            writer.AppendLine($"    public partial class {type.Name}{baseType}");
+            writer.AppendLine("    {");
+
+            if (type.Name == "Element")
+            {
+                writer.AppendLine("        public ElementId Id { get; }");
+                writer.AppendLine("        public ElementConfiguration Configure { get; } = new();");
+                writer.AppendLine();
+                writer.AppendLine("        public Element(ElementId id)");
+                writer.AppendLine("        {");
+                writer.AppendLine("            Id = id;");
+                writer.AppendLine("        }");
+                writer.AppendLine();
+                writer.AppendLine("        public Element(int id) : this(new ElementId(id)) {}");
+                writer.AppendLine("    }");
+                writer.AppendLine();
+                writer.AppendLine("    public partial class ElementConfiguration");
+                writer.AppendLine("    {");
+                writer.AppendLine("        public Func<Guid, Parameter>? GetParameter { get; set; }");
+                writer.AppendLine("        public Action? Dispose { get; set; }");
+                writer.AppendLine("    }");
+                writer.AppendLine("}");
+                return writer.ToString();
+            }
+            else if (type.Name == "Parameter")
+            {
+                writer.AppendLine("        public new ParameterConfiguration Configure { get; } = new();");
+                writer.AppendLine();
+                writer.AppendLine("        public Parameter(ElementId id) : base(id) { }");
+                writer.AppendLine("        public Parameter(int id) : base(id) { }");
+                writer.AppendLine();
+                writer.AppendLine("        public Guid GUID => Configure.get_Guid?.Invoke() ?? throw new InvalidOperationException(\"get_Guid not configured.\");");
+                writer.AppendLine("    }");
+                writer.AppendLine();
+                writer.AppendLine("    public partial class ParameterConfiguration : ElementConfiguration");
+                writer.AppendLine("    {");
+                writer.AppendLine("        public Func<Guid>? get_Guid { get; set; }");
+                writer.AppendLine("    }");
+                writer.AppendLine("}");
+                return writer.ToString();
+            }
+            else if (type.Name == "ElementId")
+            {
+                writer.AppendLine("        public int IntegerValue { get; }");
+                writer.AppendLine();
+                writer.AppendLine("        public ElementId(int value)");
+                writer.AppendLine("        {");
+                writer.AppendLine("            IntegerValue = value;");
+                writer.AppendLine("        }");
+                writer.AppendLine("    }");
+                writer.AppendLine("}");
+                return writer.ToString();
+            }
+            else
+            {
+                writer.AppendLine("    }");
+                writer.AppendLine("}");
+                return writer.ToString();
+            }
+        }
+    }
+}

--- a/src/RevitStubGenerator/RevitStubGenerator.csproj
+++ b/src/RevitStubGenerator/RevitStubGenerator.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/RevitTestStubs/Autodesk/Revit/DB/Element.cs
+++ b/src/RevitTestStubs/Autodesk/Revit/DB/Element.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Autodesk.Revit.DB
+{
+    public partial class Element : IDisposable
+    {
+        public ElementId Id { get; }
+
+        public ElementConfiguration Configure { get; } = new();
+
+        public Element(ElementId id)
+        {
+            Id = id;
+        }
+
+        public Element(int id)
+            : this(new ElementId(id))
+        {
+        }
+
+        public virtual Parameter GetParameter(Guid guid)
+        {
+            return Configure.GetParameter?.Invoke(guid)
+                ?? throw new InvalidOperationException("GetParameter not configured.");
+        }
+
+        public virtual void Dispose()
+        {
+            Configure.Dispose?.Invoke();
+        }
+    }
+
+    public partial class ElementConfiguration
+    {
+        public Func<Guid, Parameter>? GetParameter { get; set; }
+        public Action? Dispose { get; set; }
+    }
+}

--- a/src/RevitTestStubs/Autodesk/Revit/DB/ElementId.cs
+++ b/src/RevitTestStubs/Autodesk/Revit/DB/ElementId.cs
@@ -1,0 +1,12 @@
+namespace Autodesk.Revit.DB
+{
+    public partial class ElementId
+    {
+        public int IntegerValue { get; }
+
+        public ElementId(int value)
+        {
+            IntegerValue = value;
+        }
+    }
+}

--- a/src/RevitTestStubs/Autodesk/Revit/DB/Parameter.cs
+++ b/src/RevitTestStubs/Autodesk/Revit/DB/Parameter.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Autodesk.Revit.DB
+{
+    public partial class Parameter : Element
+    {
+        public new ParameterConfiguration Configure { get; } = new();
+
+        public Parameter(ElementId id) : base(id) { }
+
+        public Parameter(int id) : base(id) { }
+
+        public Guid GUID
+        {
+            get
+            {
+                return Configure.get_Guid?.Invoke()
+                    ?? throw new InvalidOperationException("get_Guid not configured.");
+            }
+        }
+    }
+
+    public partial class ParameterConfiguration : ElementConfiguration
+    {
+        public Func<Guid>? get_Guid { get; set; }
+    }
+}

--- a/src/RevitTestStubs/RevitTestStubs.csproj
+++ b/src/RevitTestStubs/RevitTestStubs.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>RevitTestStubs</PackageId>
+    <Version>1.0.0</Version>
+    <Description>Source only stubs for a subset of the Revit API used for unit testing.</Description>
+    <PackageTags>revit;stubs;test;source-only</PackageTags>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**/*.cs" Pack="true" PackagePath="buildTransitive" />
+  </ItemGroup>
+</Project>

--- a/tests/RevitTestStubs.Tests/RevitStubTests.cs
+++ b/tests/RevitTestStubs.Tests/RevitStubTests.cs
@@ -1,0 +1,43 @@
+using System;
+using Autodesk.Revit.DB;
+using Xunit;
+
+namespace RevitTestStubs.Tests
+{
+    public class RevitStubTests
+    {
+        [Fact]
+        public void Element_Returns_Configured_Parameter_With_Correct_GUID()
+        {
+            var expectedGuid = Guid.NewGuid();
+
+            var parameter = new Parameter(101);
+            parameter.Configure.get_Guid = () => expectedGuid;
+
+            var element = new Element(200);
+            element.Configure.GetParameter = guid =>
+            {
+                Assert.Equal(expectedGuid, guid);
+                return parameter;
+            };
+
+            bool elementDisposed = false;
+            bool parameterDisposed = false;
+
+            element.Configure.Dispose = () => elementDisposed = true;
+            parameter.Configure.Dispose = () => parameterDisposed = true;
+
+            var retrievedParameter = element.GetParameter(expectedGuid);
+            var actualGuid = retrievedParameter.GUID;
+
+            element.Dispose();
+            parameter.Dispose();
+
+            Assert.Equal(expectedGuid, actualGuid);
+            Assert.Equal(101, retrievedParameter.Id.IntegerValue);
+            Assert.Equal(200, element.Id.IntegerValue);
+            Assert.True(elementDisposed);
+            Assert.True(parameterDisposed);
+        }
+    }
+}

--- a/tests/RevitTestStubs.Tests/RevitTestStubs.Tests.csproj
+++ b/tests/RevitTestStubs.Tests/RevitTestStubs.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\RevitTestStubs\RevitTestStubs.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a solution with three projects
- implement Element, ElementId and Parameter stubs with a Configure property
- add a stub generator that uses MetadataLoadContext
- pack stubs as a source-only nuget package via buildTransitive
- add xUnit tests demonstrating usage

## Testing
- `dotnet build RevitTestStubs.sln -c Release` *(fails: unable to restore packages)*
- `dotnet test RevitTestStubs.sln -c Release` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_685fbfd3c4f48326ae5f94cdd3d49409