### PR TITLE
Support generic methods in stub generator

### DIFF
--- a/tests/RevitStubGenerator.Tests/GeneratorTests.cs
+++ b/tests/RevitStubGenerator.Tests/GeneratorTests.cs
@@ -15,6 +15,17 @@ public class GeneratorTests
         _output = output;
     }
 
+    [Fact]
+    public void Generates_generic_method_stub()
+    {
+        var result = GenerateClass(typeof(GenericSample));
+        _output.WriteLine(result);
+
+        Assert.Contains("public virtual T GetValue<T>(System.String key)", result);
+        Assert.Contains("Func<System.String, System.Type, object?>? GetValue_0", result);
+        Assert.Contains("typeof(T)", result);
+    }
+
     private static string GenerateClass(Type type)
     {
         var programType = Assembly.Load("RevitStubGenerator").GetType("RevitStubGenerator.StubGenerator", true)!;
@@ -145,4 +156,9 @@ public class GeneratorTests
     }
 
     public delegate int SampleDelegate(string text);
+
+    public class GenericSample
+    {
+        public T GetValue<T>(string key) => default!;
+    }
 }


### PR DESCRIPTION
## Summary
- implement generic method handling in StubGenerator
- add `UsesGenericParameter` helper
- generate Type-based delegate signatures for generic methods
- expand interface method generation for generics
- test generic method generation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68603999cbf8832683eef091c03ea4bd