### PR TITLE
Improve README with generator focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,56 @@
 # RevitTestStubs
 
-This repository demonstrates how to create stubs for assemblies that do not expose interfaces. It includes a small utility for generating stub classes from the Autodesk Revit API and a source only package that provides a few hand written stubs used for unit testing. The package exposes minimal `ElementId`, `Element` and `Parameter` implementations with a `Configure` property that allows delegates to be attached for mocking behaviour.
-The stub generator can now output *every* public class from a Revit assembly. For each type a matching `Configure` class is produced with delegates for all public members so behaviour can easily be mocked.
+This repository demonstrates how to create mockable stubs for assemblies that do
+not expose interfaces. The heart of the repo is a small generator that reads any
+.NET assembly and emits partial classes for all public types. Each generated
+class is accompanied by a `Configure` helper that exposes delegates for every
+public method and property so behaviour can easily be mocked in unit tests.
+
+The repository also contains a few generated Revit stubs under `example/`. They
+represent a small portion of a larger stub and illustrate how the approach can
+be used in practice.
+
+## Generating stubs
+
+Run the generator with the path to an assembly and an output folder. The tool
+uses `MetadataLoadContext` so it can analyse the types without loading any of
+the assembly's dependencies at runtime. For example, to process Revit's
+`RevitAPI.dll` you could run:
+
+```bash
+dotnet tool run stubgen \
+    "C:\Program Files\Autodesk\Revit 2024\RevitAPI.dll" Generated\RevitStubs
+```
+
+The command above will create a tree of partial classes under the specified
+output folder. Each class includes a nested `Configuration` object where you can
+assign delegates for all public members.
+
+## Using the stubs
+
+The example stubs in `example/` show how the generated classes can be used in
+tests. Below is a simplified unit test demonstrating how a portion of the
+`Element` stub can be configured:
+
+```csharp
+using Autodesk.Revit.DB;
+using Xunit;
+
+[Fact]
+public void Can_mock_element_parameter()
+{
+    var element = new Element(42);
+    var expected = new Parameter(1);
+    element.Configure.GetParameter = _ => expected;
+
+    var result = element.GetParameter(Guid.NewGuid());
+
+    Assert.Same(expected, result);
+}
+```
+
 
 ## Projects
 
-- **RevitStubGenerator** – console application that uses `MetadataLoadContext` to read a Revit assembly and emit partial class stubs. It now scans every public type and generates a partial implementation together with a `Configure` class containing delegates for all members. The generated files can be added to the source package.
-- **RevitTestStubs** – example library located under the `example` folder that ships source files in a `buildTransitive` folder so they become part of any project referencing the package.
-
-To create a package run `dotnet pack example/RevitTestStubs` which will produce a source only NuGet package.
+- **StubGenerator** – dotnet tool that uses `MetadataLoadContext` to read any .NET assembly and emit partial class stubs. It scans every public type and generates a partial implementation together with a `Configure` class containing delegates for all members.
+- **RevitTestStubs** – example library located under the `example` folder containing a few stubbed types from Revit's API.

--- a/RevitTestStubs.sln
+++ b/RevitTestStubs.sln
@@ -7,11 +7,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitTestStubs", "example\RevitTestStubs\RevitTestStubs.csproj", "{CA82C141-E22A-4CCE-ACD5-E987A4A846E7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitStubGenerator", "src\RevitStubGenerator\RevitStubGenerator.csproj", "{A5052F16-7CF2-4C78-9F6B-867243693F67}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StubGenerator", "src\StubGenerator\StubGenerator.csproj", "{A5052F16-7CF2-4C78-9F6B-867243693F67}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitStubGenerator.Tests", "tests\RevitStubGenerator.Tests\RevitStubGenerator.Tests.csproj", "{F192128F-7071-42A3-BC02-CCF375A3F05F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StubGenerator.Tests", "tests\StubGenerator.Tests\StubGenerator.Tests.csproj", "{F192128F-7071-42A3-BC02-CCF375A3F05F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/example/RevitTestStubs/RevitTestStubs.csproj
+++ b/example/RevitTestStubs/RevitTestStubs.csproj
@@ -3,16 +3,5 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageId>RevitTestStubs</PackageId>
-    <Version>1.0.0</Version>
-    <Description>Source only stubs for a subset of the Revit API used for unit testing.</Description>
-    <PackageTags>revit;stubs;test;source-only</PackageTags>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="**/*.cs" Pack="true" PackagePath="buildTransitive" />
-  </ItemGroup>
 </Project>

--- a/src/StubGenerator/Program.cs
+++ b/src/StubGenerator/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 
-namespace RevitStubGenerator
+namespace StubGenerator
 {
     internal class Program
     {
@@ -9,7 +9,7 @@ namespace RevitStubGenerator
         {
             if (args.Length < 2)
             {
-                Console.WriteLine("Usage: RevitStubGenerator <assemblyPath> <outputDir>");
+                Console.WriteLine("Usage: stubgen <assemblyPath> <outputDir>");
                 return;
             }
 

--- a/src/StubGenerator/StubGenerator.cs
+++ b/src/StubGenerator/StubGenerator.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 
-namespace RevitStubGenerator
+namespace StubGenerator
 {
     public static class StubGenerator
     {

--- a/src/StubGenerator/StubGenerator.csproj
+++ b/src/StubGenerator/StubGenerator.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>stubgen</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/StubGenerator.Tests/GeneratorTests.cs
+++ b/tests/StubGenerator.Tests/GeneratorTests.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace RevitStubGenerator.Tests;
+namespace StubGenerator.Tests;
 
 public class GeneratorTests
 {
@@ -28,35 +28,35 @@ public class GeneratorTests
 
     private static string GenerateClass(Type type)
     {
-        var programType = Assembly.Load("RevitStubGenerator").GetType("RevitStubGenerator.StubGenerator", true)!;
+        var programType = Assembly.Load("StubGenerator").GetType("StubGenerator.StubGenerator", true)!;
         var method = programType.GetMethod("GenerateClassStub", BindingFlags.Public | BindingFlags.Static)!;
         return (string)method.Invoke(null, new object?[] { type })!;
     }
 
     private static string GenerateInterface(Type type)
     {
-        var programType = Assembly.Load("RevitStubGenerator").GetType("RevitStubGenerator.StubGenerator", true)!;
+        var programType = Assembly.Load("StubGenerator").GetType("StubGenerator.StubGenerator", true)!;
         var method = programType.GetMethod("GenerateInterfaceStub", BindingFlags.Public | BindingFlags.Static)!;
         return (string)method.Invoke(null, new object?[] { type })!;
     }
 
     private static string GenerateEnum(Type type)
     {
-        var programType = Assembly.Load("RevitStubGenerator").GetType("RevitStubGenerator.StubGenerator", true)!;
+        var programType = Assembly.Load("StubGenerator").GetType("StubGenerator.StubGenerator", true)!;
         var method = programType.GetMethod("GenerateEnumStub", BindingFlags.Public | BindingFlags.Static)!;
         return (string)method.Invoke(null, new object?[] { type })!;
     }
 
     private static string GenerateStruct(Type type)
     {
-        var programType = Assembly.Load("RevitStubGenerator").GetType("RevitStubGenerator.StubGenerator", true)!;
+        var programType = Assembly.Load("StubGenerator").GetType("StubGenerator.StubGenerator", true)!;
         var method = programType.GetMethod("GenerateStructStub", BindingFlags.Public | BindingFlags.Static)!;
         return (string)method.Invoke(null, new object?[] { type })!;
     }
 
     private static string GenerateDelegate(Type type)
     {
-        var programType = Assembly.Load("RevitStubGenerator").GetType("RevitStubGenerator.StubGenerator", true)!;
+        var programType = Assembly.Load("StubGenerator").GetType("StubGenerator.StubGenerator", true)!;
         var method = programType.GetMethod("GenerateDelegateStub", BindingFlags.Public | BindingFlags.Static)!;
         return (string)method.Invoke(null, new object?[] { type })!;
     }
@@ -67,7 +67,7 @@ public class GeneratorTests
         var result = GenerateClass(typeof(SampleClass));
         _output.WriteLine(result);
 
-        Assert.Contains("namespace RevitStubGenerator.Tests", result);
+        Assert.Contains("namespace StubGenerator.Tests", result);
         Assert.Contains("public partial class SampleClass", result);
         Assert.Contains("public SampleClassConfiguration Configure", result);
         Assert.Contains("public virtual System.String Echo(System.String text)", result);
@@ -125,7 +125,7 @@ public class GeneratorTests
     [Fact]
     public void GenerateClassStub_is_public()
     {
-        var method = typeof(RevitStubGenerator.StubGenerator).GetMethod("GenerateClassStub", BindingFlags.Public | BindingFlags.Static);
+        var method = typeof(global::StubGenerator.StubGenerator).GetMethod("GenerateClassStub", BindingFlags.Public | BindingFlags.Static);
         Assert.NotNull(method);
     }
 

--- a/tests/StubGenerator.Tests/StubGenerator.Tests.csproj
+++ b/tests/StubGenerator.Tests/StubGenerator.Tests.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\RevitStubGenerator\RevitStubGenerator.csproj" />
+    <ProjectReference Include="..\..\src\StubGenerator\StubGenerator.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- refocus README on generator that works for any assembly
- clarify that Revit stubs are just an example
- rename generator to StubGenerator CLI tool
- strip source-only packaging from example stubs

## Testing
- `dotnet test tests/StubGenerator.Tests/StubGenerator.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68604d7902ec8326baaf3a221aed6714