### PR TITLE
Add interface implementation to class stubs

### DIFF
--- a/src/StubGenerator/StubGenerator.cs
+++ b/src/StubGenerator/StubGenerator.cs
@@ -58,8 +58,21 @@ namespace StubGenerator
             var currentNs = type.Namespace!;
             var usings = CollectNamespaces(type);
 
-            var baseType = type.BaseType != null && type.BaseType != typeof(object)
-                ? $" : {GetTypeName(type.BaseType, currentNs)}"
+            var baseParts = new List<string>();
+            if (type.BaseType != null && type.BaseType != typeof(object))
+                baseParts.Add(GetTypeName(type.BaseType, currentNs));
+
+            var interfaces = type.GetInterfaces();
+            if (type.BaseType != null)
+            {
+                var baseInterfaces = new HashSet<Type>(type.BaseType.GetInterfaces());
+                interfaces = interfaces.Where(i => !baseInterfaces.Contains(i)).ToArray();
+            }
+            foreach (var iface in interfaces)
+                baseParts.Add(GetTypeName(iface, currentNs));
+
+            var baseType = baseParts.Count > 0
+                ? " : " + string.Join(", ", baseParts)
                 : string.Empty;
 
             var writer = new System.Text.StringBuilder();

--- a/tests/StubGenerator.Tests/GeneratorTests.cs
+++ b/tests/StubGenerator.Tests/GeneratorTests.cs
@@ -123,6 +123,25 @@ public class GeneratorTests
     }
 
     [Fact]
+    public void Generates_class_with_interface()
+    {
+        var result = GenerateClass(typeof(InterfaceImpl));
+        _output.WriteLine(result);
+
+        Assert.Contains("public partial class InterfaceImpl : System.IDisposable", result);
+    }
+
+    [Fact]
+    public void Generates_class_without_duplicate_interfaces()
+    {
+        var result = GenerateClass(typeof(DerivedImpl));
+        _output.WriteLine(result);
+
+        Assert.Contains("public partial class DerivedImpl : BaseImpl, System.IDisposable", result);
+        Assert.DoesNotContain("IExample", result);
+    }
+
+    [Fact]
     public void Generates_event_stub()
     {
         var result = GenerateClass(typeof(EventSample));
@@ -179,5 +198,25 @@ public class GeneratorTests
     public class GenericSample
     {
         public T GetValue<T>(string key) => default!;
+    }
+
+    public interface IExample
+    {
+        void Do();
+    }
+
+    public class BaseImpl : IExample
+    {
+        public void Do() { }
+    }
+
+    public class DerivedImpl : BaseImpl, IDisposable
+    {
+        public void Dispose() { }
+    }
+
+    public class InterfaceImpl : IDisposable
+    {
+        public void Dispose() { }
     }
 }


### PR DESCRIPTION
## Summary
- add interface inheritance handling when generating class stubs
- avoid duplicates if the base type already implements an interface
- test new behaviour for classes implementing interfaces
- compile example stubs after generation

## Testing
- `dotnet test -c Release -v minimal`
- `dotnet build example/RevitTestStubs/RevitTestStubs.csproj -c Release -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_686061efee48832683644dc08e5cfd0c