### PR TITLE
Add support for ref/out parameters

### DIFF
--- a/tests/StubGenerator.Tests/GeneratorTests.cs
+++ b/tests/StubGenerator.Tests/GeneratorTests.cs
@@ -173,6 +173,18 @@ public class GeneratorTests
         Assert.NotNull(method);
     }
 
+    [Fact]
+    public void Generates_ref_out_methods()
+    {
+        var result = GenerateClass(typeof(RefOutSample));
+        _output.WriteLine(result);
+
+        Assert.Contains("public virtual void Increment(ref System.Int32 value)", result);
+        Assert.Contains("public Action<System.Int32>? Increment_0", result);
+        Assert.Contains("public virtual System.Boolean TryParse(System.String text, out System.Int32 value)", result);
+        Assert.Contains("public Func<System.String, System.Int32, System.Boolean>? TryParse_1", result);
+    }
+
     public class SampleClass
     {
         public int Number { get; set; }
@@ -238,5 +250,11 @@ public class GeneratorTests
             get => string.Empty;
             set { }
         }
+    }
+
+    public class RefOutSample
+    {
+        public void Increment(ref int value) { }
+        public bool TryParse(string text, out int value) { value = 0; return false; }
     }
 }


### PR DESCRIPTION
## Summary
- handle `ByRef` types in `GetTypeName`
- include `ref`/`out` keywords in generated signatures
- strip references when building delegate types
- add tests covering `ref`/`out` parameters

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686065d8b56c8326bde8a35cfa03b9b6